### PR TITLE
Exclude compileJava from test command

### DIFF
--- a/diffblue.yml
+++ b/diffblue.yml
@@ -1,5 +1,5 @@
 buildCmd: ./gradlew compileJava
-testCmd: ./gradlew test
+testCmd: ./gradlew test -x compileJava
 cbmcArguments:
   java-max-input-array-length: 10
   unwind: 10


### PR DESCRIPTION
Just in case anyone is using this, it'll currently fail coverage reporting because of the compileJava noticing the instrumentation as a change and overwriting it.